### PR TITLE
Fix broken links for "Theme Tutorial" and "Theme Reference"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There's loads of potential for customization, you just have to work creatively a
 
 [GRUB-Tweaks](https://github.com/VandalByte/grub-tweaks) - Multiple guides on various tweaks and additions you can make to further customize, or repair, your GRUB install.
 
-[Theme Tutorial](web.archive.org/web/20241209100014/http://wiki.rosalab.ru/en/index.php/Grub2_theme_tutorial) and [Theme References](http://web.archive.org/web/20241209094940/http://wiki.rosalab.ru/en/index.php/Grub2_theme_/_reference) - Pretty complex, but the best set of information I've managed to find so far. It may be easier to start by taking an existing theme and making edits to it yourself, rather than diving straight in and starting from scratch.
+[Theme Tutorial](http://web.archive.org/web/20241209100014/http://wiki.rosalab.ru/en/index.php/Grub2_theme_tutorial) and [Theme References](http://web.archive.org/web/20241209094940/http://wiki.rosalab.ru/en/index.php/Grub2_theme_/_reference) - Pretty complex, but the best set of information I've managed to find so far. It may be easier to start by taking an existing theme and making edits to it yourself, rather than diving straight in and starting from scratch.
 
 [Background Cycler](https://github.com/Jacksaur/GRUB-Background-Cycler) - Script I made that will cycle a theme to a different background each time your system is rebooted. The Cron job can be modified to run at specific amounts of time instead if desired.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There's loads of potential for customization, you just have to work creatively a
 
 [GRUB-Tweaks](https://github.com/VandalByte/grub-tweaks) - Multiple guides on various tweaks and additions you can make to further customize, or repair, your GRUB install.
 
-[Theme Tutorial](http://wiki.rosalab.ru/en/index.php/Grub2_theme_tutorial) and [Theme References](http://wiki.rosalab.ru/en/index.php/Grub2_theme_/_reference) - Pretty complex, but the best set of information I've managed to find so far. It may be easier to start by taking an existing theme and making edits to it yourself, rather than diving straight in and starting from scratch.
+[Theme Tutorial](web.archive.org/web/20241209100014/http://wiki.rosalab.ru/en/index.php/Grub2_theme_tutorial) and [Theme References](http://web.archive.org/web/20241209094940/http://wiki.rosalab.ru/en/index.php/Grub2_theme_/_reference) - Pretty complex, but the best set of information I've managed to find so far. It may be easier to start by taking an existing theme and making edits to it yourself, rather than diving straight in and starting from scratch.
 
 [Background Cycler](https://github.com/Jacksaur/GRUB-Background-Cycler) - Script I made that will cycle a theme to a different background each time your system is rebooted. The Cron job can be modified to run at specific amounts of time instead if desired.
 


### PR DESCRIPTION
## Fix broken links for "Theme Tutorial" and "Theme Reference"

> First of all, thank you so much for compiling this amazing list of GRUB themes :)
> I've been a long time fan of this repository and discovered several different themes through it.

I've been wanting to explore GRUB theme creation for a while, but today, when I went to checkout the tutorial and reference links they were no longer available. 
Fortunately, there are captures of these pages in the Wayback Machine (made in December 2024), so, I thought I'd update the links here for anyone interested.

### Let me know your thoughts :)